### PR TITLE
swap from httpcall.get2 to httpcall.get and parse resp.body

### DIFF
--- a/lib/facter/util/aws_tags.rb
+++ b/lib/facter/util/aws_tags.rb
@@ -12,8 +12,12 @@ module Facter::Util::AWSTags
   def self.get_tags
 
     httpcall = Net::HTTP.new(INSTANCE_HOST)
-    resp, instance_id = httpcall.get2(INSTANCE_ID_URL)
-    resp, region = httpcall.get2(INSTANCE_REGION_URL)
+
+    resp = httpcall.get(INSTANCE_ID_URL)
+    instance_id = resp.body
+
+    resp = httpcall.get(INSTANCE_REGION_URL)
+    region = resp.body
 
     # Cut out availability zone marker.
     # For example if region == "us-east-1c" after cutting out it will be


### PR DESCRIPTION
The response from ´httpcall.get2` somehow returned empty response, swapping to
`httpcall.get` and get the `resp.body` gets the proper instance_id and region.

Thanks!